### PR TITLE
Ensure we load the module with an absolute namespace

### DIFF
--- a/worthwhile-models/app/models/concerns/worthwhile/generic_file_base.rb
+++ b/worthwhile-models/app/models/concerns/worthwhile/generic_file_base.rb
@@ -12,7 +12,7 @@ module Worthwhile
     include Sufia::GenericFile::Metadata
     include Sufia::GenericFile::Versions
     include Sufia::Permissions::Readable
-    include CurationConcern::VersionedContent
+    include ::CurationConcern::VersionedContent
 
     included do
       belongs_to :batch, property: :is_part_of, class_name: 'ActiveFedora::Base'


### PR DESCRIPTION
Fixes a NameError (uninitalized constant
Worthwhile::CurationConcern::VersionedContent)
